### PR TITLE
chore(dev-tool): fsd-check OS 호환성 개선 및 CI 워크플로우 추가

### DIFF
--- a/.github/workflows/fsd-check.yml
+++ b/.github/workflows/fsd-check.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  check-fsd:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/fsd-check.yml
+++ b/.github/workflows/fsd-check.yml
@@ -1,0 +1,25 @@
+name: FSD Rule Check
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn fsd

--- a/__tools__/fsd-check/fsd-check.js
+++ b/__tools__/fsd-check/fsd-check.js
@@ -8,6 +8,7 @@ import {
   hasPublicAPI,
   isAllowImport,
   isFSDLayer,
+  normalizePath,
 } from './utils.js';
 import { errorMessages } from './error-message.js';
 
@@ -46,7 +47,7 @@ function checkPublicAPI(targetFolder, filePath) {
 /** cross API 방식이 아닌 경우의 에러 메시지 반환 */
 function checkCrossAPI(targetFolder, filePath) {
   // NOTE: cross api 방식이 아닌 경우
-  if (!filePath.includes(`@${CROSS_API_SYMBOL}${SLASH}`)) return null;
+  if (!normalizePath(filePath).includes(`@${CROSS_API_SYMBOL}/`)) return null;
 
   // NOTE: cross api 레이어인 경우
   if (getCurrentLayer(targetFolder, filePath) === CROSS_API_LAYER) return null;
@@ -57,8 +58,8 @@ function checkCrossAPI(targetFolder, filePath) {
 /** invalid alias 사용 경우의 에러 메시지 반환 */
 function checkInvalidAlias(targetFolder, filePath, importPath) {
   const invalidPrefixes = LAYER.map(layer => `@/${targetFolder}/${layer}`);
-
-  if (!invalidPrefixes.some(prefix => importPath.startsWith(prefix))) return null;
+  const normalized = normalizePath(importPath);
+  if (!invalidPrefixes.some(prefix => normalized.startsWith(prefix))) return null;
 
   return errorMessages.invalidAlias(filePath, importPath, targetFolder);
 }
@@ -78,7 +79,7 @@ function checkSlicePublicAPIImport(filePath, importPath, importLayer) {
   if (!['pages', 'widgets', 'features', 'entities'].includes(importLayer)) return null;
 
   // NOTE: "@pages/auth/ui/LoginPage" → ["@pages","auth","ui","LoginPage"]
-  const splitedPath = importPath.split('/');
+  const splitedPath = normalizePath(importPath).split('/');
 
   // NOTE: @pages/{domain}
   if (splitedPath.length === 2) return null;

--- a/__tools__/fsd-check/utils.js
+++ b/__tools__/fsd-check/utils.js
@@ -46,19 +46,20 @@ export function getImportsFromFile(filePath) {
 
 /** 파일의 현재 레이어를 가져옵니다. */
 export function getCurrentLayer(targetFolder, filePath) {
-  const relative = filePath.split(`${targetFolder}${SLASH}`)[1];
-  return relative.split(SLASH)[0]; // ✅ 물리적 파일 경로는 OS 구분자(path.sep) 사용
+  const relative = path.relative(targetFolder, filePath);
+  const normalized = normalizePath(relative);
+  return normalized.split(SLASH)[0];
 }
 
 /** import 구문의 레이어를 가져옵니다. */
 export function getImportLayer(importPath) {
-  const normalized = normalizePath(importPath); // ✅ 윈도우/맥 동일하게 처리
+  const normalized = normalizePath(importPath);
   return normalized.split('/')[0].replace(/^@/, '');
 }
 
 /** FSD 레이어인지 확인합니다. */
 export function isFSDLayer(importPath) {
-  const normalized = normalizePath(importPath); // ✅ importPath는 항상 normalize
+  const normalized = normalizePath(importPath);
   return ['@app', '@pages', '@widgets', '@features', '@entities', '@shared'].some(p =>
     normalized.startsWith(p),
   );
@@ -84,8 +85,8 @@ export function hasErrorMessages(errorMessages) {
  * 예: pages/auth
  */
 export function getLayerSlice(targetFolder, filePath) {
-  const relativePath = filePath.split(`${targetFolder}${SLASH}`)[1];
-  const normalized = normalizePath(relativePath); // ✅ 윈도우 대비: relativePath를 POSIX 스타일로 통일
+  const relative = path.relative(targetFolder, filePath);
+  const normalized = normalizePath(relative);
   return normalized.split('/').slice(0, 2).join('/');
 }
 


### PR DESCRIPTION
## 개요
- fsd-check 툴을 window, mac os에서 안정적으로 사용할 수 있게 수정
- workflow에서 fsd-check가 여러 os에서 정상작동하는지 확인할 수 있도록 설정
    - ubuntu, mac, window 

<img width="1832" height="1108" alt="image" src="https://github.com/user-attachments/assets/679a499c-1345-48f2-99a7-ce928fea71fa" />

