### PR TITLE
fix: chatBottomSheet 전송 이슈 + 피드 프로필 사진 누르면 AnotherUserPage로 navigate

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-native-gesture-handler": "^2.29.0",
     "react-native-keyboard-controller": "^1.19.5",
     "react-native-linear-gradient": "^2.8.3",
-    "react-native-modal": "14.0.0-rc.1",
+    "react-native-modal": "^14.0.0-rc.1",
     "react-native-modalize": "^2.1.1",
     "react-native-portalize": "^1.0.7",
     "react-native-reanimated": "4.1.0",

--- a/src/entities/feed/model/index.ts
+++ b/src/entities/feed/model/index.ts
@@ -45,6 +45,7 @@ export interface Feed extends FeedBase {
   bookmarkCount: number;
   commentCount: number;
   viewCount: number;
+  userId: string;
 }
 
 export interface FeedDetail extends FeedBase {
@@ -73,7 +74,7 @@ export interface FeedDetail extends FeedBase {
   viewCount: number;
   followerCount: number;
   isOwner: boolean;
-  userId: number;
+  userId: string;
 }
 
 export interface FeedPage {

--- a/src/features/chat/ui/ChatInput.tsx
+++ b/src/features/chat/ui/ChatInput.tsx
@@ -44,9 +44,9 @@ const ChatInput = forwardRef<TextInput, Props>(
               ref={ref}
               value={inputValue}
               onChangeText={setInputValue}
-              // multiline={true}
+              multiline={true}
               onSubmitEditing={handleSubmit}
-              submitBehavior="submit"
+              submitBehavior="newline"
               onContentSizeChange={e => {
                 const newHeight = e.nativeEvent.contentSize.height;
                 setInputHeight(Math.max(40, Math.min(newHeight, 140)));

--- a/src/features/feed/ui/FeedCard.tsx
+++ b/src/features/feed/ui/FeedCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, Image, Pressable } from 'react-native';
+import { View, Text, Image, Pressable, TouchableOpacity } from 'react-native';
 import ClockSvg from '@/assets/img/feed/clock-icon.svg';
 import StarSvg from '@/assets/img/feed/star-icon.svg';
 import NoneUserSvg from '@/assets/img/none-profile-img.svg';
@@ -23,14 +23,22 @@ const FeedCard = ({ feed, navigation }: Props) => {
         >
           {/* 프로필 섹션 */}
           <View className="mb-6 flex-row items-center">
-            {feed.profileImage ? (
-              <Image
-                source={{ uri: feed.profileImage }}
-                className="mr-3 h-[55px] w-[55px] rounded-full bg-g2"
-              />
-            ) : (
-              <NoneUserSvg width={55} height={55} style={{ marginRight: 12 }} />
-            )}
+            <TouchableOpacity
+              onPress={() =>
+                navigation.navigate('AnotherUserPage', {
+                  userId: feed.userId ?? '0',
+                })
+              }
+            >
+              {feed.profileImage ? (
+                <Image
+                  source={{ uri: feed.profileImage }}
+                  className="mr-3 h-[55px] w-[55px] rounded-full bg-g2"
+                />
+              ) : (
+                <NoneUserSvg width={55} height={55} style={{ marginRight: 12 }} />
+              )}
+            </TouchableOpacity>
             <View>
               <Text className="mb-1 text-[16px] font-bold">{feed.title}</Text>
               <Text className="text-[14px] font-semibold color-g2">

--- a/src/features/user/ui/FollowItem.tsx
+++ b/src/features/user/ui/FollowItem.tsx
@@ -39,7 +39,7 @@ const FollowItem = ({ user, navigation }: Props) => {
       className="flex-row items-center justify-between bg-white px-4 py-3"
       onPress={() =>
         navigation.navigate('AnotherUserPage', {
-          userId: user.userId ?? '1',
+          userId: user.userId ?? '0',
         })
       }
     >

--- a/src/pages/feed/ui/FeedChatBottomSheet.tsx
+++ b/src/pages/feed/ui/FeedChatBottomSheet.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, TextInput, FlatList, RefreshControl, Platform } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  FlatList,
+  RefreshControl,
+  Platform,
+  Dimensions,
+} from 'react-native';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { ChatInput, CommentItem, useCommentsQuery, useCreateCommentMutation } from '@features/chat';
 import { Comment } from '@entities/comment';
@@ -10,6 +18,8 @@ interface Props {
   bottomSheetVisible: boolean;
   bottomSheetClose: () => void;
 }
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
 
 const FeedChatBottomSheet = ({ feedId, bottomSheetVisible, bottomSheetClose }: Props) => {
   const inputRef = useRef<TextInput>(null);
@@ -36,11 +46,12 @@ const FeedChatBottomSheet = ({ feedId, bottomSheetVisible, bottomSheetClose }: P
       content: inputValue,
       parentId: replyTo ? Number(replyTo.id) : undefined,
     });
+    setInputValue('');
 
-    // 자동 스크롤
+    // NOTE: 충분히 자동 스크롤 200ms
     setTimeout(() => {
       flatListRef.current?.scrollToEnd({ animated: true });
-    }, 100);
+    }, 200);
   };
 
   const handleReplyPress = (comment: Comment) => {
@@ -54,9 +65,9 @@ const FeedChatBottomSheet = ({ feedId, bottomSheetVisible, bottomSheetClose }: P
 
   return (
     <BottomSheetModal visible={bottomSheetVisible} onClose={bottomSheetClose}>
-      <View className="h-[570px]">
+      <View style={{ height: SCREEN_HEIGHT * 0.8 }}>
         <KeyboardAvoidingView
-          behavior="translate-with-padding"
+          behavior={Platform.OS === 'ios' ? undefined : 'padding'}
           keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 160}
           style={{ flex: 1 }}
         >

--- a/src/pages/feed/ui/FeedDetail.tsx
+++ b/src/pages/feed/ui/FeedDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Text, View, Image, Pressable, ScrollView } from 'react-native';
+import { Text, View, Image, Pressable, ScrollView, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import BookmarkOffSvg from '@/assets/img/feed/bookmark-off-icon.svg';
 import BookmarkOnSvg from '@/assets/img/feed/bookmark-on-icon.svg';
@@ -119,14 +119,22 @@ const FeedDetail = ({ navigation, route }: FeedDetailProps) => {
             {/* 작성자, 팔로워, subtitle */}
             <View className="mb-4 w-full flex-row items-center justify-between gap-[8px]">
               <View className="flex-1 flex-row items-start">
-                {feedDetail.profileImage ? (
-                  <Image
-                    source={{ uri: feedDetail.profileImage }}
-                    className="mr-[12px] h-[48px] w-[48px] rounded-2xl"
-                  />
-                ) : (
-                  <NoneUserSvg width={48} height={48} style={{ marginRight: 12 }} />
-                )}
+                <TouchableOpacity
+                  onPress={() =>
+                    navigation.navigate('AnotherUserPage', {
+                      userId: feedDetail.userId ?? '0',
+                    })
+                  }
+                >
+                  {feedDetail.profileImage ? (
+                    <Image
+                      source={{ uri: feedDetail.profileImage }}
+                      className="mr-[12px] h-[48px] w-[48px] rounded-2xl"
+                    />
+                  ) : (
+                    <NoneUserSvg width={48} height={48} style={{ marginRight: 12 }} />
+                  )}
+                </TouchableOpacity>
                 <View className="flex-1">
                   <Text className="mb-2 text-[12px] font-medium">
                     <Text className="text-[18px] font-bold">{feedDetail.nickname}</Text>

--- a/src/shared/ui/modal/bottomSheet/BottomSheetModal.tsx
+++ b/src/shared/ui/modal/bottomSheet/BottomSheetModal.tsx
@@ -33,6 +33,9 @@ const BottomSheetModal = ({ visible, onClose, children }: Props) => {
       handlePosition="inside"
       handleStyle={{ width: 50, backgroundColor: '#ccc' }}
       modalStyle={{ borderTopLeftRadius: 20, borderTopRightRadius: 20 }}
+      scrollViewProps={{
+        keyboardShouldPersistTaps: 'handled',
+      }}
     >
       {children}
     </Modalize>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6217,7 +6217,7 @@ react-native-linear-gradient@^2.8.3:
   resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz#9a116649f86d74747304ee13db325e20b21e564f"
   integrity sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==
 
-react-native-modal@14.0.0-rc.1:
+react-native-modal@^14.0.0-rc.1:
   version "14.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-14.0.0-rc.1.tgz#d193af884c910ec34a4953508c7656b5fc83d7d4"
   integrity sha512-v5pvGyx1FlmBzdHyPqBsYQyS2mIJhVmuXyNo5EarIzxicKhuoul6XasXMviGcXboEUT0dTYWs88/VendojPiVw==


### PR DESCRIPTION
## 개요

chatBottomSheet 전송 이슈 + 피드 프로필 사진 누르면 AnotherUserPage로 navigate

## 변경 사항

modalize 깃허브에서 해당 이슈를 겪고 있는 사람을 찾음
https://github.com/jeremybarbet/react-native-modalize/issues/370


전체 플로우 영상
https://github.com/user-attachments/assets/d6e9739a-f200-4bad-806d-c590c63554dc


## 체크리스트

- [ ] **Husky 사전검사 통과** (commit/push 전 훅 수행)

- [x] **Android 테스트 완료**

- [ ] **iOS 테스트 완료**

### 관련 이슈

<!-- - Closes #번호 / Resolves #번호 -->
